### PR TITLE
fix: Remove protected customer scopes from app config

### DIFF
--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -14,7 +14,8 @@ api_version = "2025-04"
 
 [access_scopes]
 # Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
-scopes = "customer_read_customers,customer_read_orders,customer_read_store_credit_account_transactions,customer_read_store_credit_accounts,unauthenticated_read_product_listings"
+# Add following additional scopes when configuring customer accounts authentication: customer_read_customers,customer_read_orders,customer_read_store_credit_account_transactions,customer_read_store_credit_accounts
+scopes = "unauthenticated_read_product_listings"
 
 [auth]
 redirect_urls = [ "https://shop-chat-agent.com/api/auth" ]


### PR DESCRIPTION
## Summary

- Removed protected `customer_*` scopes from `shopify.app.toml` that require Partner Dashboard approval
- Added comment documenting the scopes to re-enable after approval is granted

## Problem

Running `shopify app dev` failed with:
```
❌ Error
└  Missing permission for access scopes
```

The `customer_*` scopes are protected and require approval in the Shopify Partner Dashboard before use.

## Scopes removed (documented in comments)

- `customer_read_customers`
- `customer_read_orders`
- `customer_read_store_credit_account_transactions`
- `customer_read_store_credit_accounts`

## Test plan

- [x] `shopify app dev` runs without scope permission errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)