### PR TITLE
fix: Update Claude model to valid model name

### DIFF
--- a/app/services/config.server.js
+++ b/app/services/config.server.js
@@ -6,7 +6,7 @@
 export const AppConfig = {
   // API Configuration
   api: {
-    defaultModel: 'claude-3-5-sonnet-latest',
+    defaultModel: 'claude-sonnet-4-20250514',
     maxTokens: 2000,
     defaultPromptType: 'standardAssistant',
   },


### PR DESCRIPTION
## Summary

Updated the default Claude model from `claude-3-5-sonnet-latest` to `claude-sonnet-4-20250514`.

## Problem

The app was returning 404 errors when making API calls:
```
NotFoundError: 404 {"type":"error","error":{"type":"not_found_error","message":"model: claude-3-5-sonnet-latest"}}
```

## Solution

Changed to a valid model identifier `claude-sonnet-4-20250514`.

## Test plan

- [x] App no longer returns 404 model not found errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)