### PR TITLE
fixed chat bubble button overlaps send button

### DIFF
--- a/extensions/chat-bubble/assets/chat.css
+++ b/extensions/chat-bubble/assets/chat.css
@@ -24,6 +24,9 @@
   }
   
   @media (max-width: 480px) {
+    .shop-ai-chat-container.chat-open .shop-ai-chat-bubble {
+      display: none;
+    }
     .shop-ai-chat-bubble {
       width: 50px;
       height: 50px;

--- a/extensions/chat-bubble/assets/chat.js
+++ b/extensions/chat-bubble/assets/chat.js
@@ -114,9 +114,10 @@
        * Toggle chat window visibility
        */
       toggleChatWindow: function() {
-        const { chatWindow, chatInput } = this.elements;
+        const { chatWindow, chatInput,container } = this.elements;
 
         chatWindow.classList.toggle('active');
+        container.classList.toggle("chat-open"); // ✅ added
 
         if (chatWindow.classList.contains('active')) {
           // On mobile, prevent body scrolling and delay focus
@@ -138,9 +139,10 @@
        * Close chat window
        */
       closeChatWindow: function() {
-        const { chatWindow, chatInput } = this.elements;
+        const { chatWindow, chatInput ,container} = this.elements;
 
         chatWindow.classList.remove('active');
+        container.classList.remove("chat-open"); // ✅ added
 
         // On mobile, blur input to hide keyboard and enable body scrolling
         if (this.isMobile) {


### PR DESCRIPTION
Fixes: #47

Fixed mobile UI overlap issue by hiding the chat bubble when the chat window is open in mobile view. Added a `chat-open` class in JS to control visibility via responsive CSS. Tested on mobile and desktop with no regressions.

<img width="378" height="671" alt="Screenshot from 2026-01-07 16-48-22" src="https://github.com/user-attachments/assets/e7d5f067-2f8e-4015-a484-111e0836453e" />
<img width="378" height="671" alt="Screenshot from 2026-01-07 16-48-15" src="https://github.com/user-attachments/assets/cb53f43e-0083-4c41-b3c9-1b4d7399832f" />
