### PR TITLE
Make conversation IDs unguessable and scope chats to their shop

### DIFF
--- a/app/auth.server.js
+++ b/app/auth.server.js
@@ -7,6 +7,22 @@
  * @param {string} conversationId - The conversation ID to track the auth flow
  * @returns {Promise<Object>} - Object containing the auth URL and conversation ID
  */
+export function encodeOAuthState(conversationId, shopId) {
+  return `${conversationId}:${shopId}`;
+}
+
+export function decodeOAuthState(state) {
+  if (!state) return { conversationId: null, shopId: null };
+
+  const separatorIndex = state.lastIndexOf(":");
+  if (separatorIndex === -1) return { conversationId: null, shopId: null };
+
+  return {
+    conversationId: state.slice(0, separatorIndex),
+    shopId: state.slice(separatorIndex + 1)
+  };
+}
+
 export async function generateAuthUrl(conversationId, shopId) {
   const { storeCodeVerifier } = await import('./db.server');
 
@@ -19,18 +35,14 @@ export async function generateAuthUrl(conversationId, shopId) {
   const redirectUri = process.env.REDIRECT_URL;
 
   // Include the conversation ID and shop ID in the state parameter for tracking
-  const state = `${conversationId}-${shopId}`;
+  const state = encodeOAuthState(conversationId, shopId);
 
   // Generate code verifier and challenge
   const verifier = generateCodeVerifier();
   const challenge = await generateCodeChallenge(verifier);
 
   // Store the code verifier in the database
-  try {
-    await storeCodeVerifier(state, verifier);
-  } catch (error) {
-    console.error('Failed to store code verifier:', error);
-  }
+  await storeCodeVerifier(state, verifier);
 
   // Set code_challenge and code_challenge_method parameters
   const codeChallengeMethod = "S256";
@@ -42,7 +54,7 @@ export async function generateAuthUrl(conversationId, shopId) {
 
 
   // Construct the authorization URL with hardcoded shop ID
-  const authUrl = `${baseAuthUrl}?client_id=${clientId}&scope=${encodeURIComponent(scope)}&redirect_uri=${encodeURIComponent(redirectUri)}&response_type=${responseType}&state=${state}&code_challenge=${challenge}&code_challenge_method=${codeChallengeMethod}`;
+  const authUrl = `${baseAuthUrl}?client_id=${clientId}&scope=${encodeURIComponent(scope)}&redirect_uri=${encodeURIComponent(redirectUri)}&response_type=${responseType}&state=${encodeURIComponent(state)}&code_challenge=${challenge}&code_challenge_method=${codeChallengeMethod}`;
 
   return {
     url: authUrl,

--- a/app/auth.server.js
+++ b/app/auth.server.js
@@ -8,19 +8,27 @@
  * @returns {Promise<Object>} - Object containing the auth URL and conversation ID
  */
 export function encodeOAuthState(conversationId, shopId) {
-  return `${conversationId}:${shopId}`;
+  return `${conversationId}:${shopId}:${crypto.randomUUID()}`;
 }
 
 export function decodeOAuthState(state) {
   if (!state) return { conversationId: null, shopId: null };
 
-  const separatorIndex = state.lastIndexOf(":");
-  if (separatorIndex === -1) return { conversationId: null, shopId: null };
+  const parts = state.split(":");
+  if (parts.length >= 2 && parts[0] && /^\d+$/.test(parts[1])) {
+    return { conversationId: parts[0], shopId: parts[1] };
+  }
 
-  return {
-    conversationId: state.slice(0, separatorIndex),
-    shopId: state.slice(separatorIndex + 1)
-  };
+  const legacySeparatorIndex = state.lastIndexOf("-");
+  if (legacySeparatorIndex === -1) return { conversationId: null, shopId: null };
+
+  const conversationId = state.slice(0, legacySeparatorIndex);
+  const shopId = state.slice(legacySeparatorIndex + 1);
+  if (!conversationId || !/^\d+$/.test(shopId)) {
+    return { conversationId: null, shopId: null };
+  }
+
+  return { conversationId, shopId };
 }
 
 export async function generateAuthUrl(conversationId, shopId) {

--- a/app/db.server.js
+++ b/app/db.server.js
@@ -135,17 +135,42 @@ export async function getCustomerToken(conversationId) {
 }
 
 /**
+ * Look up a conversation by ID
+ * @param {string} conversationId - The conversation ID
+ * @returns {Promise<Object|null>} - The conversation or null if not found
+ */
+export async function getConversation(conversationId) {
+  try {
+    return await prisma.conversation.findUnique({
+      where: { id: conversationId }
+    });
+  } catch (error) {
+    console.error('Error retrieving conversation:', error);
+    return null;
+  }
+}
+
+/**
  * Create or update a conversation in the database
  * @param {string} conversationId - The conversation ID
+ * @param {string} shopId - The shop the conversation belongs to
  * @returns {Promise<Object>} - The created or updated conversation
  */
-export async function createOrUpdateConversation(conversationId) {
+export async function createOrUpdateConversation(conversationId, shopId) {
   try {
+    if (!shopId) {
+      throw new Error("Cannot save a conversation without a shop ID");
+    }
+
     const existingConversation = await prisma.conversation.findUnique({
       where: { id: conversationId }
     });
 
     if (existingConversation) {
+      if (existingConversation.shopId !== shopId) {
+        throw new Error("Cannot save a message to a conversation from another shop");
+      }
+
       return await prisma.conversation.update({
         where: { id: conversationId },
         data: {
@@ -156,7 +181,8 @@ export async function createOrUpdateConversation(conversationId) {
 
     return await prisma.conversation.create({
       data: {
-        id: conversationId
+        id: conversationId,
+        shopId
       }
     });
   } catch (error) {
@@ -170,12 +196,13 @@ export async function createOrUpdateConversation(conversationId) {
  * @param {string} conversationId - The conversation ID
  * @param {string} role - The message role (user or assistant)
  * @param {string} content - The message content
+ * @param {string} shopId - The shop the conversation belongs to
  * @returns {Promise<Object>} - The saved message
  */
-export async function saveMessage(conversationId, role, content) {
+export async function saveMessage(conversationId, role, content, shopId) {
   try {
     // Ensure the conversation exists
-    await createOrUpdateConversation(conversationId);
+    await createOrUpdateConversation(conversationId, shopId);
 
     // Create the message
     return await prisma.message.create({

--- a/app/db.server.js
+++ b/app/db.server.js
@@ -1,4 +1,5 @@
 import { PrismaClient } from "@prisma/client";
+import { conversationBelongsToShop } from "./services/conversation-access.server.js";
 
 if (process.env.NODE_ENV !== "production") {
   if (!global.prismaGlobal) {
@@ -24,7 +25,7 @@ export async function storeCodeVerifier(state, verifier) {
   try {
     return await prisma.codeVerifier.create({
       data: {
-        id: `cv_${Date.now()}`,
+        id: `cv_${crypto.randomUUID()}`,
         state,
         verifier,
         expiresAt
@@ -114,10 +115,19 @@ export async function storeCustomerToken(conversationId, accessToken, expiresAt)
 /**
  * Get a customer access token by conversation ID
  * @param {string} conversationId - The conversation ID
+ * @param {string} shopId - The shop the conversation belongs to
  * @returns {Promise<Object|null>} - The customer token or null if not found/expired
  */
-export async function getCustomerToken(conversationId) {
+export async function getCustomerToken(conversationId, shopId) {
   try {
+    const conversation = await prisma.conversation.findUnique({
+      where: { id: conversationId }
+    });
+
+    if (!conversationBelongsToShop(conversation, shopId)) {
+      return null;
+    }
+
     const token = await prisma.customerToken.findFirst({
       where: {
         conversationId,

--- a/app/mcp-client.js
+++ b/app/mcp-client.js
@@ -39,7 +39,7 @@ class MCPClient {
       console.log(`Connecting to MCP server at ${this.customerMcpEndpoint}`);
 
       if (this.conversationId) {
-        const dbToken = await getCustomerToken(this.conversationId);
+        const dbToken = await getCustomerToken(this.conversationId, this.shopId);
 
         if (dbToken && dbToken.accessToken) {
           this.customerAccessToken = dbToken.accessToken;
@@ -178,7 +178,7 @@ class MCPClient {
       let accessToken = this.customerAccessToken;
 
       if (!accessToken || accessToken === "") {
-        const dbToken = await getCustomerToken(this.conversationId);
+        const dbToken = await getCustomerToken(this.conversationId, this.shopId);
 
         if (dbToken && dbToken.accessToken) {
           accessToken = dbToken.accessToken;

--- a/app/routes/auth.callback.jsx
+++ b/app/routes/auth.callback.jsx
@@ -1,4 +1,5 @@
 import { getCodeVerifier, storeCustomerToken, getCustomerAccountUrls } from "../db.server";
+import { decodeOAuthState } from "../auth.server";
 
 /**
  * Handle OAuth callback from Shopify Customer API
@@ -7,10 +8,14 @@ export async function loader({ request }) {
   const url = new URL(request.url);
   const code = url.searchParams.get("code");
   const state = url.searchParams.get("state");
-  const [conversationId, shopId] = state.split("-");
+  const { conversationId, shopId } = decodeOAuthState(state);
 
   if (!code) {
     return new Response(JSON.stringify({ error: "Authorization code is missing" }), { status: 400 });
+  }
+
+  if (!conversationId || !shopId) {
+    return new Response(JSON.stringify({ error: "Authorization state is invalid" }), { status: 400 });
   }
 
   try {
@@ -91,9 +96,9 @@ export async function loader({ request }) {
  */
 async function exchangeCodeForToken(code, state) {
   const clientId = process.env.SHOPIFY_API_KEY;
-  const [conversationId, shopId] = state.split("-");
-  if (!clientId || !shopId) {
-    throw new Error("SHOPIFY_CLIENT_ID and SHOPIFY_SHOP_ID environment variables are required");
+  const { conversationId, shopId } = decodeOAuthState(state);
+  if (!clientId || !conversationId || !shopId) {
+    throw new Error("SHOPIFY_CLIENT_ID and a valid authorization state are required");
   }
 
   const redirectUri = process.env.REDIRECT_URL;
@@ -109,15 +114,14 @@ async function exchangeCodeForToken(code, state) {
   let codeVerifier = "";
   try {
     const verifierRecord = await getCodeVerifier(state);
-    if (verifierRecord) {
-      codeVerifier = verifierRecord.verifier;
-    } else {
-      console.warn("Code verifier not found for state:", state);
-      // Proceed anyway, since we might be using an older flow without PKCE
+    if (!verifierRecord) {
+      throw new Error("Code verifier not found");
     }
+
+    codeVerifier = verifierRecord.verifier;
   } catch (error) {
     console.error("Error retrieving code verifier:", error);
-    // Proceed anyway and attempt the token exchange
+    throw error;
   }
 
   const requestBody = {

--- a/app/routes/auth.token-status.jsx
+++ b/app/routes/auth.token-status.jsx
@@ -19,9 +19,20 @@ export async function loader({ request }) {
     });
   }
 
+  const shopId = request.headers.get("X-Shopify-Shop-Id");
+  if (!shopId) {
+    return new Response(JSON.stringify({
+      status: "error",
+      message: "Missing shop identifier"
+    }), {
+      status: 400,
+      headers: corsHeaders(request)
+    });
+  }
+
   try {
     // Check if a token exists for this conversation ID
-    const token = await getCustomerToken(conversationId);
+    const token = await getCustomerToken(conversationId, shopId);
 
     if (token) {
       // Token exists and is valid
@@ -60,7 +71,7 @@ function corsHeaders(request) {
   return {
     "Access-Control-Allow-Origin": origin,
     "Access-Control-Allow-Methods": "GET, OPTIONS",
-    "Access-Control-Allow-Headers": "Content-Type, Accept",
+    "Access-Control-Allow-Headers": "Content-Type, Accept, X-Shopify-Shop-Id",
     "Access-Control-Max-Age": "86400"
   };
 }

--- a/app/routes/chat.jsx
+++ b/app/routes/chat.jsx
@@ -8,7 +8,12 @@ import AppConfig from "../services/config.server";
 import { createSseStream } from "../services/streaming.server";
 import { createClaudeService } from "../services/claude.server";
 import { createToolService } from "../services/tool.server";
-import { conversationBelongsToShop } from "../services/conversation-access.server";
+import {
+  getSseHeaders,
+  jsonChatResponse,
+  preflightChatResponse,
+  resolveChatConversationId
+} from "../services/chat-request.server.js";
 
 
 /**
@@ -17,10 +22,7 @@ import { conversationBelongsToShop } from "../services/conversation-access.serve
 export async function loader({ request }) {
   // Handle OPTIONS requests (CORS preflight)
   if (request.method === "OPTIONS") {
-    return new Response(null, {
-      status: 204,
-      headers: getCorsHeaders(request)
-    });
+    return preflightChatResponse(request);
   }
 
   const url = new URL(request.url);
@@ -36,7 +38,7 @@ export async function loader({ request }) {
   }
 
   // API-only: reject all other requests
-  return new Response(JSON.stringify({ error: AppConfig.errorMessages.apiUnsupported }), { status: 400, headers: getCorsHeaders(request) });
+  return jsonChatResponse(request, { error: AppConfig.errorMessages.apiUnsupported }, 400);
 }
 
 /**
@@ -44,10 +46,7 @@ export async function loader({ request }) {
  */
 export async function action({ request }) {
   if (request.method === "OPTIONS") {
-    return new Response(null, {
-      status: 204,
-      headers: getCorsHeaders(request)
-    });
+    return preflightChatResponse(request);
   }
 
   return handleChatRequest(request);
@@ -63,26 +62,18 @@ async function handleHistoryRequest(request, conversationId) {
   const shopId = request.headers.get("X-Shopify-Shop-Id");
 
   if (!shopId) {
-    return new Response(
-      JSON.stringify({ error: AppConfig.errorMessages.missingShopIdentifier }),
-      { status: 400, headers: getCorsHeaders(request) }
-    );
+    return jsonChatResponse(request, { error: AppConfig.errorMessages.missingShopIdentifier }, 400);
   }
 
   const conversation = await getConversation(conversationId);
 
-  // The shop header is client-provided, so this is defense-in-depth; the primary
-  // protection is that conversation IDs are server-created and unguessable.
-  if (!conversationBelongsToShop(conversation, shopId)) {
-    return new Response(
-      JSON.stringify({ error: AppConfig.errorMessages.conversationNotFound }),
-      { status: 404, headers: getCorsHeaders(request) }
-    );
+  if (!conversation?.shopId || conversation.shopId !== shopId) {
+    return jsonChatResponse(request, { error: AppConfig.errorMessages.conversationNotFound }, 404);
   }
 
   const messages = await getConversationHistory(conversationId);
 
-  return new Response(JSON.stringify({ messages }), { headers: getCorsHeaders(request) });
+  return jsonChatResponse(request, { messages });
 }
 
 /**
@@ -94,10 +85,7 @@ async function handleChatRequest(request) {
   try {
     const shopId = request.headers.get("X-Shopify-Shop-Id");
     if (!shopId) {
-      return new Response(
-        JSON.stringify({ error: AppConfig.errorMessages.missingShopIdentifier }),
-        { status: 400, headers: getSseHeaders(request) }
-      );
+      return jsonChatResponse(request, { error: AppConfig.errorMessages.missingShopIdentifier }, 400);
     }
 
     // Get message data from request body
@@ -106,26 +94,23 @@ async function handleChatRequest(request) {
 
     // Validate required message
     if (!userMessage) {
-      return new Response(
-        JSON.stringify({ error: AppConfig.errorMessages.missingMessage }),
-        { status: 400, headers: getSseHeaders(request) }
-      );
+      return jsonChatResponse(request, { error: AppConfig.errorMessages.missingMessage }, 400);
     }
 
-    // Continue an existing conversation only if it belongs to this shop; otherwise
-    // start a fresh one with an unguessable ID so conversations can't be enumerated.
-    let conversationId = body.conversation_id;
-    if (conversationId) {
-      const conversation = await getConversation(conversationId);
-      if (!conversationBelongsToShop(conversation, shopId)) {
-        return new Response(
-          JSON.stringify({ error: AppConfig.errorMessages.conversationNotFound }),
-          { status: 404, headers: getSseHeaders(request) }
-        );
-      }
-    } else {
-      conversationId = crypto.randomUUID();
+    // The shop header is client-provided, so this is defense-in-depth; the primary
+    // protection is that conversation IDs are server-created and unguessable.
+    const conversationResolution = await resolveChatConversationId({
+      requestedConversationId: body.conversation_id,
+      shopId,
+      findConversation: getConversation,
+      createId: () => crypto.randomUUID()
+    });
+
+    if (conversationResolution.notFound) {
+      return jsonChatResponse(request, { error: AppConfig.errorMessages.conversationNotFound }, 404);
     }
+
+    const conversationId = conversationResolution.conversationId;
 
     const promptType = body.prompt_type || AppConfig.api.defaultPromptType;
 
@@ -145,10 +130,7 @@ async function handleChatRequest(request) {
     });
   } catch (error) {
     console.error('Error in chat request handler:', error);
-    return new Response(JSON.stringify({ error: error.message }), {
-      status: 500,
-      headers: getCorsHeaders(request)
-    });
+    return jsonChatResponse(request, { error: error.message }, 500);
   }
 }
 
@@ -374,41 +356,4 @@ async function getCustomerAccountUrls(shopDomain, conversationId) {
     console.error("Error getting customer MCP API URL:", error);
     return null;
   }
-}
-
-/**
- * Gets CORS headers for the response
- * @param {Request} request - The request object
- * @returns {Object} CORS headers object
- */
-function getCorsHeaders(request) {
-  const origin = request.headers.get("Origin") || "*";
-  const requestHeaders = request.headers.get("Access-Control-Request-Headers") || "Content-Type, Accept";
-
-  return {
-    "Access-Control-Allow-Origin": origin,
-    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-    "Access-Control-Allow-Headers": requestHeaders,
-    "Access-Control-Allow-Credentials": "true",
-    "Access-Control-Max-Age": "86400" // 24 hours
-  };
-}
-
-/**
- * Get SSE headers for the response
- * @param {Request} request - The request object
- * @returns {Object} SSE headers object
- */
-function getSseHeaders(request) {
-  const origin = request.headers.get("Origin") || "*";
-
-  return {
-    "Content-Type": "text/event-stream",
-    "Cache-Control": "no-cache",
-    "Connection": "keep-alive",
-    "Access-Control-Allow-Credentials": "true",
-    "Access-Control-Allow-Origin": origin,
-    "Access-Control-Allow-Methods": "GET,OPTIONS,POST",
-    "Access-Control-Allow-Headers": "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version"
-  };
 }

--- a/app/routes/chat.jsx
+++ b/app/routes/chat.jsx
@@ -3,11 +3,12 @@
  * Handles chat interactions with Claude API and tools
  */
 import MCPClient from "../mcp-client";
-import { saveMessage, getConversationHistory, storeCustomerAccountUrls, getCustomerAccountUrls as getCustomerAccountUrlsFromDb } from "../db.server";
+import { saveMessage, getConversation, getConversationHistory, storeCustomerAccountUrls, getCustomerAccountUrls as getCustomerAccountUrlsFromDb } from "../db.server";
 import AppConfig from "../services/config.server";
 import { createSseStream } from "../services/streaming.server";
 import { createClaudeService } from "../services/claude.server";
 import { createToolService } from "../services/tool.server";
+import { conversationBelongsToShop } from "../services/conversation-access.server";
 
 
 /**
@@ -42,6 +43,13 @@ export async function loader({ request }) {
  * React Router action function for handling POST requests
  */
 export async function action({ request }) {
+  if (request.method === "OPTIONS") {
+    return new Response(null, {
+      status: 204,
+      headers: getCorsHeaders(request)
+    });
+  }
+
   return handleChatRequest(request);
 }
 
@@ -52,6 +60,26 @@ export async function action({ request }) {
  * @returns {Response} JSON response with chat history
  */
 async function handleHistoryRequest(request, conversationId) {
+  const shopId = request.headers.get("X-Shopify-Shop-Id");
+
+  if (!shopId) {
+    return new Response(
+      JSON.stringify({ error: AppConfig.errorMessages.missingShopIdentifier }),
+      { status: 400, headers: getCorsHeaders(request) }
+    );
+  }
+
+  const conversation = await getConversation(conversationId);
+
+  // The shop header is client-provided, so this is defense-in-depth; the primary
+  // protection is that conversation IDs are server-created and unguessable.
+  if (!conversationBelongsToShop(conversation, shopId)) {
+    return new Response(
+      JSON.stringify({ error: AppConfig.errorMessages.conversationNotFound }),
+      { status: 404, headers: getCorsHeaders(request) }
+    );
+  }
+
   const messages = await getConversationHistory(conversationId);
 
   return new Response(JSON.stringify({ messages }), { headers: getCorsHeaders(request) });
@@ -64,6 +92,14 @@ async function handleHistoryRequest(request, conversationId) {
  */
 async function handleChatRequest(request) {
   try {
+    const shopId = request.headers.get("X-Shopify-Shop-Id");
+    if (!shopId) {
+      return new Response(
+        JSON.stringify({ error: AppConfig.errorMessages.missingShopIdentifier }),
+        { status: 400, headers: getSseHeaders(request) }
+      );
+    }
+
     // Get message data from request body
     const body = await request.json();
     const userMessage = body.message;
@@ -76,8 +112,21 @@ async function handleChatRequest(request) {
       );
     }
 
-    // Generate or use existing conversation ID
-    const conversationId = body.conversation_id || Date.now().toString();
+    // Continue an existing conversation only if it belongs to this shop; otherwise
+    // start a fresh one with an unguessable ID so conversations can't be enumerated.
+    let conversationId = body.conversation_id;
+    if (conversationId) {
+      const conversation = await getConversation(conversationId);
+      if (!conversationBelongsToShop(conversation, shopId)) {
+        return new Response(
+          JSON.stringify({ error: AppConfig.errorMessages.conversationNotFound }),
+          { status: 404, headers: getSseHeaders(request) }
+        );
+      }
+    } else {
+      conversationId = crypto.randomUUID();
+    }
+
     const promptType = body.prompt_type || AppConfig.api.defaultPromptType;
 
     // Create a stream for the response
@@ -157,7 +206,7 @@ async function handleChatSession({
     let productsToDisplay = [];
 
     // Save user message to the database
-    await saveMessage(conversationId, 'user', userMessage);
+    await saveMessage(conversationId, 'user', userMessage, shopId);
 
     // Fetch all messages from the database for this conversation
     const dbMessages = await getConversationHistory(conversationId);
@@ -202,7 +251,7 @@ async function handleChatSession({
               content: message.content
             });
 
-            saveMessage(conversationId, message.role, JSON.stringify(message.content))
+            saveMessage(conversationId, message.role, JSON.stringify(message.content), shopId)
               .catch((error) => {
                 console.error("Error saving message to database:", error);
               });
@@ -235,7 +284,8 @@ async function handleChatSession({
                 toolUseId,
                 conversationHistory,
                 stream.sendMessage,
-                conversationId
+                conversationId,
+                shopId
               );
             } else {
               await toolService.handleToolSuccess(
@@ -244,7 +294,8 @@ async function handleChatSession({
                 toolUseId,
                 conversationHistory,
                 productsToDisplay,
-                conversationId
+                conversationId,
+                shopId
               );
             }
 

--- a/app/services/chat-request.server.js
+++ b/app/services/chat-request.server.js
@@ -1,0 +1,76 @@
+/**
+ * Shared helpers for the /chat HTTP contract.
+ */
+import { conversationBelongsToShop } from "./conversation-access.server.js";
+
+export function preflightChatResponse(request) {
+  return new Response(null, {
+    status: 204,
+    headers: getCorsHeaders(request)
+  });
+}
+
+export function jsonChatResponse(request, body, status = 200, extraHeaders = {}) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      ...getCorsHeaders(request),
+      "Content-Type": "application/json",
+      ...extraHeaders
+    }
+  });
+}
+
+export async function resolveChatConversationId({ requestedConversationId, shopId, findConversation, createId }) {
+  if (!requestedConversationId) {
+    return { conversationId: createId(), notFound: false };
+  }
+
+  const conversation = await findConversation(requestedConversationId);
+  if (!conversation) {
+    return { conversationId: createId(), notFound: false };
+  }
+
+  if (!conversationBelongsToShop(conversation, shopId)) {
+    return { conversationId: null, notFound: true };
+  }
+
+  return { conversationId: requestedConversationId, notFound: false };
+}
+
+/**
+ * Gets CORS headers for the response
+ * @param {Request} request - The request object
+ * @returns {Object} CORS headers object
+ */
+export function getCorsHeaders(request) {
+  const origin = request.headers.get("Origin") || "*";
+  const requestHeaders = request.headers.get("Access-Control-Request-Headers") || "Content-Type, Accept";
+
+  return {
+    "Access-Control-Allow-Origin": origin,
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+    "Access-Control-Allow-Headers": requestHeaders,
+    "Access-Control-Allow-Credentials": "true",
+    "Access-Control-Max-Age": "86400" // 24 hours
+  };
+}
+
+/**
+ * Get SSE headers for the response
+ * @param {Request} request - The request object
+ * @returns {Object} SSE headers object
+ */
+export function getSseHeaders(request) {
+  const origin = request.headers.get("Origin") || "*";
+
+  return {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    "Connection": "keep-alive",
+    "Access-Control-Allow-Credentials": "true",
+    "Access-Control-Allow-Origin": origin,
+    "Access-Control-Allow-Methods": "GET,OPTIONS,POST",
+    "Access-Control-Allow-Headers": "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version"
+  };
+}

--- a/app/services/config.server.js
+++ b/app/services/config.server.js
@@ -14,6 +14,8 @@ export const AppConfig = {
   // Error Message Templates
   errorMessages: {
     missingMessage: "Message is required",
+    missingShopIdentifier: "Shop identifier is required",
+    conversationNotFound: "Conversation not found",
     apiUnsupported: "This endpoint only supports server-sent events (SSE) requests or history requests.",
     authFailed: "Authentication failed with Claude API",
     apiKeyError: "Please check your API key in environment variables",

--- a/app/services/conversation-access.server.js
+++ b/app/services/conversation-access.server.js
@@ -1,0 +1,16 @@
+/**
+ * Conversation access checks.
+ *
+ * The shop ID header comes from the storefront client, so it is defense-in-depth
+ * rather than a cryptographic proof of shop identity. The primary protection is
+ * that server-created conversation IDs are unguessable.
+ */
+
+/**
+ * @param {Object|null} conversation - Conversation record from the database
+ * @param {string|null} shopId - Shop ID from the request
+ * @returns {boolean} - Whether this request can use the conversation
+ */
+export function conversationBelongsToShop(conversation, shopId) {
+  return Boolean(shopId && conversation?.shopId && conversation.shopId === shopId);
+}

--- a/app/services/tool.server.js
+++ b/app/services/tool.server.js
@@ -18,15 +18,16 @@ export function createToolService() {
    * @param {Array} conversationHistory - The conversation history
    * @param {Function} sendMessage - Function to send messages to the client
    * @param {string} conversationId - The conversation ID
+   * @param {string} shopId - The shop the conversation belongs to
    */
-  const handleToolError = async (toolUseResponse, toolName, toolUseId, conversationHistory, sendMessage, conversationId) => {
+  const handleToolError = async (toolUseResponse, toolName, toolUseId, conversationHistory, sendMessage, conversationId, shopId) => {
     if (toolUseResponse.error.type === "auth_required") {
       console.log("Auth required for tool:", toolName);
-      await addToolResultToHistory(conversationHistory, toolUseId, toolUseResponse.error.data, conversationId);
+      await addToolResultToHistory(conversationHistory, toolUseId, toolUseResponse.error.data, conversationId, shopId);
       sendMessage({ type: 'auth_required' });
     } else {
       console.log("Tool use error", toolUseResponse.error);
-      await addToolResultToHistory(conversationHistory, toolUseId, toolUseResponse.error.data, conversationId);
+      await addToolResultToHistory(conversationHistory, toolUseId, toolUseResponse.error.data, conversationId, shopId);
     }
   };
 
@@ -38,14 +39,15 @@ export function createToolService() {
    * @param {Array} conversationHistory - The conversation history
    * @param {Array} productsToDisplay - Array to add product results to
    * @param {string} conversationId - The conversation ID
+   * @param {string} shopId - The shop the conversation belongs to
    */
-  const handleToolSuccess = async (toolUseResponse, toolName, toolUseId, conversationHistory, productsToDisplay, conversationId) => {
+  const handleToolSuccess = async (toolUseResponse, toolName, toolUseId, conversationHistory, productsToDisplay, conversationId, shopId) => {
     // Check if this is a product search result
     if (toolName === AppConfig.tools.productSearchName) {
       productsToDisplay.push(...processProductSearchResult(toolUseResponse));
     }
 
-    addToolResultToHistory(conversationHistory, toolUseId, toolUseResponse.content, conversationId);
+    addToolResultToHistory(conversationHistory, toolUseId, toolUseResponse.content, conversationId, shopId);
   };
 
   /**
@@ -116,8 +118,9 @@ export function createToolService() {
    * @param {string} toolUseId - The ID of the tool use request
    * @param {string} content - The content of the tool result
    * @param {string} conversationId - The conversation ID
+   * @param {string} shopId - The shop the conversation belongs to
    */
-  const addToolResultToHistory = async (conversationHistory, toolUseId, content, conversationId) => {
+  const addToolResultToHistory = async (conversationHistory, toolUseId, content, conversationId, shopId) => {
     const toolResultMessage = {
       role: 'user',
       content: [{
@@ -133,7 +136,7 @@ export function createToolService() {
     // Save to database with special format to indicate tool result
     if (conversationId) {
       try {
-        await saveMessage(conversationId, 'user', JSON.stringify(toolResultMessage.content));
+        await saveMessage(conversationId, 'user', JSON.stringify(toolResultMessage.content), shopId);
       } catch (error) {
         console.error('Error saving tool result to database:', error);
       }

--- a/extensions/chat-bubble/assets/chat.js
+++ b/extensions/chat-bubble/assets/chat.js
@@ -637,7 +637,8 @@
             method: 'GET',
             headers: {
               'Accept': 'application/json',
-              'Content-Type': 'application/json'
+              'Content-Type': 'application/json',
+              'X-Shopify-Shop-Id': window.shopId
             },
             mode: 'cors'
           });

--- a/extensions/chat-bubble/assets/chat.js
+++ b/extensions/chat-bubble/assets/chat.js
@@ -782,7 +782,11 @@
           try {
             const tokenUrl = 'https://localhost:3458/auth/token-status?conversation_id=' +
               encodeURIComponent(conversationId);
-            const response = await fetch(tokenUrl);
+            const response = await fetch(tokenUrl, {
+              headers: {
+                'X-Shopify-Shop-Id': window.shopId
+              }
+            });
 
             if (!response.ok) {
               throw new Error('Token status check failed: ' + response.status);

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "prisma": "prisma",
     "graphql-codegen": "graphql-codegen",
     "vite": "vite",
-    "typecheck": "react-router typegen && tsc --noEmit"
+    "typecheck": "react-router typegen && tsc --noEmit",
+    "test": "node --test"
   },
   "type": "module",
   "engines": {

--- a/prisma/migrations/20260608000000_scope_conversations_to_shop/migration.sql
+++ b/prisma/migrations/20260608000000_scope_conversations_to_shop/migration.sql
@@ -13,5 +13,20 @@ DELETE FROM "Message" WHERE "conversationId" IN (
 );
 DELETE FROM "Conversation" WHERE "shopId" IS NULL;
 
+-- Rebuild Conversation so shopId cannot be null after legacy rows are deleted.
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Conversation" (
+  "id" TEXT NOT NULL PRIMARY KEY,
+  "shopId" TEXT NOT NULL,
+  "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" DATETIME NOT NULL
+);
+INSERT INTO "new_Conversation" ("id", "shopId", "createdAt", "updatedAt")
+SELECT "id", "shopId", "createdAt", "updatedAt" FROM "Conversation";
+DROP TABLE "Conversation";
+ALTER TABLE "new_Conversation" RENAME TO "Conversation";
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;
+
 -- CreateIndex
 CREATE INDEX "Conversation_shopId_idx" ON "Conversation"("shopId");

--- a/prisma/migrations/20260608000000_scope_conversations_to_shop/migration.sql
+++ b/prisma/migrations/20260608000000_scope_conversations_to_shop/migration.sql
@@ -1,0 +1,17 @@
+-- AlterTable
+ALTER TABLE "Conversation" ADD COLUMN "shopId" TEXT;
+
+-- Drop legacy timestamp-based conversations that cannot be safely scoped to a shop.
+DELETE FROM "CustomerToken" WHERE "conversationId" IN (
+  SELECT "id" FROM "Conversation" WHERE "shopId" IS NULL
+);
+DELETE FROM "CustomerAccountUrls" WHERE "conversationId" IN (
+  SELECT "id" FROM "Conversation" WHERE "shopId" IS NULL
+);
+DELETE FROM "Message" WHERE "conversationId" IN (
+  SELECT "id" FROM "Conversation" WHERE "shopId" IS NULL
+);
+DELETE FROM "Conversation" WHERE "shopId" IS NULL;
+
+-- CreateIndex
+CREATE INDEX "Conversation_shopId_idx" ON "Conversation"("shopId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,9 +55,12 @@ model CodeVerifier {
 
 model Conversation {
   id        String    @id
+  shopId    String?
   messages  Message[]
   createdAt DateTime  @default(now())
   updatedAt DateTime  @updatedAt
+
+  @@index([shopId])
 }
 
 model Message {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,7 +55,7 @@ model CodeVerifier {
 
 model Conversation {
   id        String    @id
-  shopId    String?
+  shopId    String
   messages  Message[]
   createdAt DateTime  @default(now())
   updatedAt DateTime  @updatedAt

--- a/test/chat-request.test.js
+++ b/test/chat-request.test.js
@@ -1,0 +1,77 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  jsonChatResponse,
+  preflightChatResponse,
+  resolveChatConversationId
+} from "../app/services/chat-request.server.js";
+
+test("pre-stream errors are JSON responses", async () => {
+  const request = new Request("https://example.com/chat", {
+    headers: { Origin: "https://shop.example.com" }
+  });
+  const response = jsonChatResponse(request, { error: "Missing shop identifier" }, 400);
+
+  assert.equal(response.status, 400);
+  assert.equal(response.headers.get("Content-Type"), "application/json");
+  assert.equal(response.headers.get("Access-Control-Allow-Origin"), "https://shop.example.com");
+  assert.deepEqual(await response.json(), { error: "Missing shop identifier" });
+});
+
+test("preflight echoes requested chat headers", () => {
+  const request = new Request("https://example.com/chat", {
+    method: "OPTIONS",
+    headers: {
+      Origin: "https://shop.example.com",
+      "Access-Control-Request-Headers": "Content-Type, X-Shopify-Shop-Id"
+    }
+  });
+  const response = preflightChatResponse(request);
+
+  assert.equal(response.status, 204);
+  assert.equal(response.headers.get("Access-Control-Allow-Headers"), "Content-Type, X-Shopify-Shop-Id");
+});
+
+test("creates a new conversation ID when none is supplied", async () => {
+  const result = await resolveChatConversationId({
+    requestedConversationId: null,
+    shopId: "123",
+    findConversation: async () => assert.fail("should not load a missing conversation ID"),
+    createId: () => "new-id"
+  });
+
+  assert.deepEqual(result, { conversationId: "new-id", notFound: false });
+});
+
+test("creates a new conversation ID for stale client state", async () => {
+  const result = await resolveChatConversationId({
+    requestedConversationId: "deleted-id",
+    shopId: "123",
+    findConversation: async () => null,
+    createId: () => "new-id"
+  });
+
+  assert.deepEqual(result, { conversationId: "new-id", notFound: false });
+});
+
+test("rejects conversations owned by a different shop", async () => {
+  const result = await resolveChatConversationId({
+    requestedConversationId: "existing-id",
+    shopId: "123",
+    findConversation: async () => ({ shopId: "456" }),
+    createId: () => assert.fail("should not mint over a wrong-shop conversation")
+  });
+
+  assert.deepEqual(result, { conversationId: null, notFound: true });
+});
+
+test("continues conversations owned by the requesting shop", async () => {
+  const result = await resolveChatConversationId({
+    requestedConversationId: "existing-id",
+    shopId: "123",
+    findConversation: async () => ({ shopId: "123" }),
+    createId: () => assert.fail("should not replace a valid conversation")
+  });
+
+  assert.deepEqual(result, { conversationId: "existing-id", notFound: false });
+});

--- a/test/chat-route.test.js
+++ b/test/chat-route.test.js
@@ -1,0 +1,79 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+let createServer;
+try {
+  ({ createServer } = await import("vite"));
+} catch {
+  createServer = null;
+}
+
+const routeTest = createServer ? test : test.skip;
+
+async function loadChatRoute() {
+  const server = await createServer({
+    appType: "custom",
+    logLevel: "silent",
+    server: { middlewareMode: true }
+  });
+
+  const route = await server.ssrLoadModule("/app/routes/chat.jsx");
+  return { server, route };
+}
+
+routeTest("chat action rejects missing shop before streaming", async () => {
+  const { server, route } = await loadChatRoute();
+  try {
+    const response = await route.action({
+      request: new Request("https://example.com/chat", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Accept": "text/event-stream"
+        },
+        body: JSON.stringify({ message: "hello" })
+      })
+    });
+
+    assert.equal(response.status, 400);
+    assert.equal(response.headers.get("Content-Type"), "application/json");
+    assert.deepEqual(await response.json(), { error: "Missing shop identifier" });
+  } finally {
+    await server.close();
+  }
+});
+
+routeTest("history loader rejects missing shop before reading history", async () => {
+  const { server, route } = await loadChatRoute();
+  try {
+    const response = await route.loader({
+      request: new Request("https://example.com/chat?history=true&conversation_id=abc")
+    });
+
+    assert.equal(response.status, 400);
+    assert.equal(response.headers.get("Content-Type"), "application/json");
+    assert.deepEqual(await response.json(), { error: "Missing shop identifier" });
+  } finally {
+    await server.close();
+  }
+});
+
+routeTest("chat preflight allows the Shopify shop header", async () => {
+  const { server, route } = await loadChatRoute();
+  try {
+    const response = await route.loader({
+      request: new Request("https://example.com/chat", {
+        method: "OPTIONS",
+        headers: {
+          Origin: "https://shop.example.com",
+          "Access-Control-Request-Headers": "Content-Type, X-Shopify-Shop-Id"
+        }
+      })
+    });
+
+    assert.equal(response.status, 204);
+    assert.equal(response.headers.get("Access-Control-Allow-Headers"), "Content-Type, X-Shopify-Shop-Id");
+  } finally {
+    await server.close();
+  }
+});

--- a/test/conversation-access.test.js
+++ b/test/conversation-access.test.js
@@ -1,0 +1,24 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { conversationBelongsToShop } from "../app/services/conversation-access.server.js";
+
+test("rejects missing conversation", () => {
+  assert.equal(conversationBelongsToShop(null, "123"), false);
+});
+
+test("rejects missing shop header", () => {
+  assert.equal(conversationBelongsToShop({ shopId: "123" }, null), false);
+});
+
+test("rejects legacy conversations with no shop", () => {
+  assert.equal(conversationBelongsToShop({ shopId: null }, null), false);
+  assert.equal(conversationBelongsToShop({ shopId: null }, "123"), false);
+});
+
+test("rejects wrong-shop conversations", () => {
+  assert.equal(conversationBelongsToShop({ shopId: "123" }, "456"), false);
+});
+
+test("allows conversations owned by the requesting shop", () => {
+  assert.equal(conversationBelongsToShop({ shopId: "123" }, "123"), true);
+});

--- a/test/oauth-state.test.js
+++ b/test/oauth-state.test.js
@@ -10,10 +10,25 @@ test("round-trips UUID conversation IDs", () => {
   assert.deepEqual(decodeOAuthState(state), { conversationId, shopId });
 });
 
+test("generates a unique state for each auth attempt", () => {
+  const conversationId = "123e4567-e89b-12d3-a456-426614174000";
+  const shopId = "987654321";
+
+  assert.notEqual(encodeOAuthState(conversationId, shopId), encodeOAuthState(conversationId, shopId));
+});
+
 test("keeps hyphenated conversation IDs intact", () => {
-  const state = "123e4567-e89b-12d3-a456-426614174000:987654321";
+  const state = "123e4567-e89b-12d3-a456-426614174000:987654321:nonce";
   assert.deepEqual(decodeOAuthState(state), {
     conversationId: "123e4567-e89b-12d3-a456-426614174000",
+    shopId: "987654321"
+  });
+});
+
+test("accepts legacy hyphen-delimited state during rollout", () => {
+  const state = "1717773330123-987654321";
+  assert.deepEqual(decodeOAuthState(state), {
+    conversationId: "1717773330123",
     shopId: "987654321"
   });
 });
@@ -21,4 +36,6 @@ test("keeps hyphenated conversation IDs intact", () => {
 test("rejects malformed state", () => {
   assert.deepEqual(decodeOAuthState(null), { conversationId: null, shopId: null });
   assert.deepEqual(decodeOAuthState("missing-separator"), { conversationId: null, shopId: null });
+  assert.deepEqual(decodeOAuthState("conversation:"), { conversationId: null, shopId: null });
+  assert.deepEqual(decodeOAuthState("conversation:not-a-shop-id"), { conversationId: null, shopId: null });
 });

--- a/test/oauth-state.test.js
+++ b/test/oauth-state.test.js
@@ -1,0 +1,24 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { encodeOAuthState, decodeOAuthState } from "../app/auth.server.js";
+
+test("round-trips UUID conversation IDs", () => {
+  const conversationId = "123e4567-e89b-12d3-a456-426614174000";
+  const shopId = "987654321";
+
+  const state = encodeOAuthState(conversationId, shopId);
+  assert.deepEqual(decodeOAuthState(state), { conversationId, shopId });
+});
+
+test("keeps hyphenated conversation IDs intact", () => {
+  const state = "123e4567-e89b-12d3-a456-426614174000:987654321";
+  assert.deepEqual(decodeOAuthState(state), {
+    conversationId: "123e4567-e89b-12d3-a456-426614174000",
+    shopId: "987654321"
+  });
+});
+
+test("rejects malformed state", () => {
+  assert.deepEqual(decodeOAuthState(null), { conversationId: null, shopId: null });
+  assert.deepEqual(decodeOAuthState("missing-separator"), { conversationId: null, shopId: null });
+});


### PR DESCRIPTION
## What this fixes

This addresses the IDOR reported in Shopify/consumer-agent#1826 for the `shop-chat-agent` reference app.

Before this PR, new conversations used `Date.now().toString()` as the ID and the history/continue paths accepted any ID they were given. That made timestamp-style conversation IDs enumerable.

## What changed

- New conversations now use `crypto.randomUUID()` instead of a timestamp.
- History reads and chat continuation now require a shop ID and reject conversations that do not belong to that shop.
- Stale/deleted `conversation_id` values on chat POST mint a fresh UUID so existing browser tabs can recover, while existing wrong-shop/null-shop conversations still return 404.
- `/chat` handles CORS preflight through both route entry points before attempting to parse a chat request body.
- Pre-stream `/chat` failures return JSON response headers instead of SSE headers.
- Legacy conversations with no `shopId` are deleted by the migration because they cannot be safely scoped.
- The migration also deletes `CustomerToken` and `CustomerAccountUrls` rows for those legacy conversations so customer auth data is not orphaned, then rebuilds `Conversation` with `shopId` non-null.
- OAuth state no longer uses a deterministic value: it carries `conversationId`, `shopId`, and a random nonce so repeated auth attempts do not collide with existing `CodeVerifier.state` rows.
- OAuth state decoding accepts the legacy hyphen-delimited production format during rollout.
- Customer-token reads now require the request `shopId` and validate that the owning conversation belongs to that shop before returning a token.
- Assistant/tool message persistence now carries `shopId`, and the DB helper refuses to save without a shop ID or to a conversation owned by another shop.
- Added Node tests for the regression cases Marcelo called out: missing shop, legacy null shop, wrong shop, valid shop, UUID OAuth state parsing, unique OAuth state, JSON pre-stream responses, stale conversation IDs, and route-level missing-shop/preflight behavior.

## Important security note

`X-Shopify-Shop-Id` is still sent by the storefront client, so it is defense-in-depth, not a cryptographic proof of shop identity. The real protection this PR adds is that conversation IDs are server-created and unguessable. A durable customer/shop identity boundary should come from routing chat through a Shopify App Proxy and reading signed proxy parameters server-side.

## Verification

- `node --test` — 16 passing, 3 Vite-backed route tests skipped locally because dependencies are not installed in this checkout.
- Syntax-checked touched JS/JSX/test files with `node --check`.
- `git diff --check`.
- SQLite migration smoke test confirmed legacy rows are deleted and `Conversation.shopId` is non-null.
