### PR TITLE
Lock down CORS and add rate limiting on the chat endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
 CLAUDE_API_KEY=YOUR_CLAUDE_API_KEY
 REDIRECT_URL=https://localhost:3458/auth/callback
 SHOPIFY_API_KEY=YOUR_APP_CLIENT_ID
+
+# Comma-separated list of storefront origins allowed to call the chat endpoints.
+# Required for Shopify storefront origins in every environment; localhost browser clients are allowed automatically in development.
+ALLOWED_ORIGINS=https://your-store.myshopify.com

--- a/app/routes/auth.token-status.jsx
+++ b/app/routes/auth.token-status.jsx
@@ -1,10 +1,23 @@
-import { getCustomerToken } from "../db.server";
+import { getConversation, getCustomerToken } from "../db.server";
+import { conversationBelongsToShop } from "../services/conversation-access.server";
+import { corsOriginHeaders } from "../services/cors.server";
+import { rateLimitExceeded } from "../services/rate-limiter.server";
 
 /**
  * API endpoint for checking if a customer token is available for a given conversation ID
  * The chat interface can poll this endpoint after displaying an auth link
  */
 export async function loader({ request }) {
+  if (rateLimitExceeded(request, "token-status", 60)) {
+    return new Response(JSON.stringify({
+      status: "error",
+      message: "Rate limit exceeded"
+    }), {
+      status: 429,
+      headers: { "Retry-After": "60", ...corsHeaders(request) }
+    });
+  }
+
   // Get conversation ID from query parameter
   const url = new URL(request.url);
   const conversationId = url.searchParams.get("conversation_id");
@@ -31,6 +44,16 @@ export async function loader({ request }) {
   }
 
   try {
+    const conversation = await getConversation(conversationId);
+    if (!conversationBelongsToShop(conversation, shopId)) {
+      return new Response(JSON.stringify({
+        status: "unauthorized"
+      }), {
+        status: 404,
+        headers: corsHeaders(request)
+      });
+    }
+
     // Check if a token exists for this conversation ID
     const token = await getCustomerToken(conversationId, shopId);
 
@@ -66,10 +89,8 @@ export async function loader({ request }) {
  * Helper to add CORS headers to the response
  */
 function corsHeaders(request) {
-  const origin = request.headers.get("Origin") || "*";
-
   return {
-    "Access-Control-Allow-Origin": origin,
+    ...corsOriginHeaders(request),
     "Access-Control-Allow-Methods": "GET, OPTIONS",
     "Access-Control-Allow-Headers": "Content-Type, Accept, X-Shopify-Shop-Id",
     "Access-Control-Max-Age": "86400"

--- a/app/routes/chat.jsx
+++ b/app/routes/chat.jsx
@@ -14,6 +14,7 @@ import {
   preflightChatResponse,
   resolveChatConversationId
 } from "../services/chat-request.server.js";
+import { rateLimitExceeded } from "../services/rate-limiter.server";
 
 
 /**
@@ -59,6 +60,12 @@ export async function action({ request }) {
  * @returns {Response} JSON response with chat history
  */
 async function handleHistoryRequest(request, conversationId) {
+  if (rateLimitExceeded(request, "history", 60)) {
+    return jsonChatResponse(request, { error: AppConfig.errorMessages.rateLimitExceeded }, 429, {
+      "Retry-After": "60"
+    });
+  }
+
   const shopId = request.headers.get("X-Shopify-Shop-Id");
 
   if (!shopId) {
@@ -83,6 +90,12 @@ async function handleHistoryRequest(request, conversationId) {
  */
 async function handleChatRequest(request) {
   try {
+    if (rateLimitExceeded(request, "chat", 20)) {
+      return jsonChatResponse(request, { error: AppConfig.errorMessages.rateLimitExceeded }, 429, {
+        "Retry-After": "60"
+      });
+    }
+
     const shopId = request.headers.get("X-Shopify-Shop-Id");
     if (!shopId) {
       return jsonChatResponse(request, { error: AppConfig.errorMessages.missingShopIdentifier }, 400);

--- a/app/services/chat-request.server.js
+++ b/app/services/chat-request.server.js
@@ -2,6 +2,7 @@
  * Shared helpers for the /chat HTTP contract.
  */
 import { conversationBelongsToShop } from "./conversation-access.server.js";
+import { corsOriginHeaders } from "./cors.server.js";
 
 export function preflightChatResponse(request) {
   return new Response(null, {
@@ -44,14 +45,12 @@ export async function resolveChatConversationId({ requestedConversationId, shopI
  * @returns {Object} CORS headers object
  */
 export function getCorsHeaders(request) {
-  const origin = request.headers.get("Origin") || "*";
   const requestHeaders = request.headers.get("Access-Control-Request-Headers") || "Content-Type, Accept";
 
   return {
-    "Access-Control-Allow-Origin": origin,
+    ...corsOriginHeaders(request),
     "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
     "Access-Control-Allow-Headers": requestHeaders,
-    "Access-Control-Allow-Credentials": "true",
     "Access-Control-Max-Age": "86400" // 24 hours
   };
 }
@@ -62,14 +61,11 @@ export function getCorsHeaders(request) {
  * @returns {Object} SSE headers object
  */
 export function getSseHeaders(request) {
-  const origin = request.headers.get("Origin") || "*";
-
   return {
     "Content-Type": "text/event-stream",
     "Cache-Control": "no-cache",
     "Connection": "keep-alive",
-    "Access-Control-Allow-Credentials": "true",
-    "Access-Control-Allow-Origin": origin,
+    ...corsOriginHeaders(request),
     "Access-Control-Allow-Methods": "GET,OPTIONS,POST",
     "Access-Control-Allow-Headers": "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version"
   };

--- a/app/services/cors.server.js
+++ b/app/services/cors.server.js
@@ -1,0 +1,52 @@
+/**
+ * Shared CORS helpers.
+ *
+ * The chat endpoints used to reflect whatever Origin they were given, which let
+ * any website read responses cross-origin. We now only echo an Origin we trust.
+ * Set ALLOWED_ORIGINS to a comma-separated list of storefront origins in
+ * production; localhost is allowed automatically in development.
+ */
+
+function allowedOrigins() {
+  return (process.env.ALLOWED_ORIGINS || "")
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+}
+
+/**
+ * @param {string|null} origin - The request's Origin header
+ * @returns {boolean} - Whether we trust this origin
+ */
+export function isAllowedOrigin(origin) {
+  if (!origin) return false;
+  if (allowedOrigins().includes(origin)) return true;
+
+  if (process.env.NODE_ENV !== "production") {
+    try {
+      const { hostname } = new URL(origin);
+      return hostname === "localhost" || hostname === "127.0.0.1";
+    } catch {
+      return false;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * CORS origin headers for a request, or an empty object when the Origin is not
+ * trusted (so the browser blocks the cross-origin read).
+ * @param {Request} request
+ * @returns {Object}
+ */
+export function corsOriginHeaders(request) {
+  const origin = request.headers.get("Origin");
+  if (!isAllowedOrigin(origin)) return {};
+
+  return {
+    "Access-Control-Allow-Origin": origin,
+    "Access-Control-Allow-Credentials": "true",
+    "Vary": "Origin"
+  };
+}

--- a/app/services/rate-limiter.server.js
+++ b/app/services/rate-limiter.server.js
@@ -1,0 +1,68 @@
+/**
+ * Tiny in-memory rate limiter (fixed window).
+ *
+ * This is per-process, which is enough for the reference app. A multi-instance
+ * deployment should swap this for a shared store (e.g. Redis).
+ */
+
+const DEFAULT_WINDOW_MS = 60 * 1000;
+const SWEEP_INTERVAL_MS = 1000;
+const buckets = new Map();
+let lastSweepAt = 0;
+
+/**
+ * @param {string} key - Identifier to rate limit on
+ * @param {number} limit - Max requests allowed within the window
+ * @param {number} [windowMs] - Window length in milliseconds
+ * @returns {boolean} - true if allowed, false if the request should be blocked
+ */
+export function allowRequest(key, limit, windowMs = DEFAULT_WINDOW_MS) {
+  const now = Date.now();
+  sweepExpiredBuckets(now);
+
+  const bucket = buckets.get(key);
+
+  if (!bucket || now >= bucket.resetAt) {
+    buckets.set(key, { count: 1, resetAt: now + windowMs });
+    return true;
+  }
+
+  if (bucket.count >= limit) {
+    return false;
+  }
+
+  bucket.count += 1;
+  return true;
+}
+
+export function rateLimitExceeded(request, endpoint, limit) {
+  const key = clientKey(request);
+  return Boolean(key && !allowRequest(`${endpoint}:${key}`, limit));
+}
+
+function sweepExpiredBuckets(now) {
+  if (now - lastSweepAt < SWEEP_INTERVAL_MS) return;
+
+  lastSweepAt = now;
+  for (const [bucketKey, bucket] of buckets) {
+    if (now >= bucket.resetAt) buckets.delete(bucketKey);
+  }
+}
+
+/**
+ * Build a rate-limit key from the caller's IP.
+ *
+ * This assumes production requests arrive through a proxy that appends to
+ * X-Forwarded-For. Direct clients can spoof this header.
+ *
+ * @param {Request} request
+ * @returns {string|null}
+ */
+export function clientKey(request) {
+  const forwarded = (request.headers.get("X-Forwarded-For") || "")
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  return forwarded[forwarded.length - 1] || null;
+}

--- a/extensions/chat-bubble/assets/chat.js
+++ b/extensions/chat-bubble/assets/chat.js
@@ -494,6 +494,26 @@
             body: requestBody
           });
 
+          if (!response.ok) {
+            let errorMessage = 'Failed to stream response';
+            try {
+              const data = await response.json();
+              errorMessage = data.error || errorMessage;
+            } catch (e) {
+              console.error('Error parsing error response:', e);
+            }
+
+            if (response.status === 429) {
+              console.error('Rate limit exceeded:', errorMessage);
+              ShopAIChat.UI.removeTypingIndicator();
+              ShopAIChat.Message.add("Sorry, our servers are currently busy. Please try again later.",
+                'assistant', messagesContainer);
+              return;
+            }
+
+            throw new Error(errorMessage);
+          }
+
           const reader = response.body.getReader();
           const decoder = new TextDecoder();
           let buffer = '';

--- a/test/chat-request.test.js
+++ b/test/chat-request.test.js
@@ -7,6 +7,9 @@ import {
 } from "../app/services/chat-request.server.js";
 
 test("pre-stream errors are JSON responses", async () => {
+  process.env.NODE_ENV = "production";
+  process.env.ALLOWED_ORIGINS = "https://shop.example.com";
+
   const request = new Request("https://example.com/chat", {
     headers: { Origin: "https://shop.example.com" }
   });
@@ -15,10 +18,14 @@ test("pre-stream errors are JSON responses", async () => {
   assert.equal(response.status, 400);
   assert.equal(response.headers.get("Content-Type"), "application/json");
   assert.equal(response.headers.get("Access-Control-Allow-Origin"), "https://shop.example.com");
+  assert.equal(response.headers.get("Vary"), "Origin");
   assert.deepEqual(await response.json(), { error: "Missing shop identifier" });
 });
 
 test("preflight echoes requested chat headers", () => {
+  process.env.NODE_ENV = "production";
+  process.env.ALLOWED_ORIGINS = "https://shop.example.com";
+
   const request = new Request("https://example.com/chat", {
     method: "OPTIONS",
     headers: {
@@ -30,6 +37,20 @@ test("preflight echoes requested chat headers", () => {
 
   assert.equal(response.status, 204);
   assert.equal(response.headers.get("Access-Control-Allow-Headers"), "Content-Type, X-Shopify-Shop-Id");
+});
+
+test("rate-limit responses are JSON and include Retry-After", () => {
+  process.env.NODE_ENV = "production";
+  process.env.ALLOWED_ORIGINS = "https://shop.example.com";
+
+  const request = new Request("https://example.com/chat", {
+    headers: { Origin: "https://shop.example.com" }
+  });
+  const response = jsonChatResponse(request, { error: "Rate limit exceeded" }, 429, { "Retry-After": "60" });
+
+  assert.equal(response.status, 429);
+  assert.equal(response.headers.get("Content-Type"), "application/json");
+  assert.equal(response.headers.get("Retry-After"), "60");
 });
 
 test("creates a new conversation ID when none is supplied", async () => {

--- a/test/chat-route.test.js
+++ b/test/chat-route.test.js
@@ -18,7 +18,9 @@ async function loadChatRoute() {
   });
 
   const route = await server.ssrLoadModule("/app/routes/chat.jsx");
-  return { server, route };
+  const rateLimiter = await server.ssrLoadModule("/app/services/rate-limiter.server.js");
+
+  return { server, route, rateLimiter };
 }
 
 routeTest("chat action rejects missing shop before streaming", async () => {
@@ -58,7 +60,62 @@ routeTest("history loader rejects missing shop before reading history", async ()
   }
 });
 
+routeTest("chat action returns a JSON 429 before streaming", async () => {
+  const { server, route, rateLimiter } = await loadChatRoute();
+  try {
+    const ip = "203.0.113.68";
+    for (let i = 0; i < 20; i++) {
+      assert.equal(rateLimiter.allowRequest(`chat:${ip}`, 20), true);
+    }
+
+    const response = await route.action({
+      request: new Request("https://example.com/chat", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Accept": "text/event-stream",
+          "X-Forwarded-For": ip,
+          "X-Shopify-Shop-Id": "123"
+        },
+        body: JSON.stringify({ message: "hello" })
+      })
+    });
+
+    assert.equal(response.status, 429);
+    assert.equal(response.headers.get("Content-Type"), "application/json");
+    assert.equal(response.headers.get("Retry-After"), "60");
+  } finally {
+    await server.close();
+  }
+});
+
+routeTest("history loader has an independent rate-limit bucket", async () => {
+  const { server, route, rateLimiter } = await loadChatRoute();
+  try {
+    const ip = "203.0.113.69";
+    for (let i = 0; i < 20; i++) {
+      assert.equal(rateLimiter.allowRequest(`chat:${ip}`, 20), true);
+    }
+
+    const response = await route.loader({
+      request: new Request("https://example.com/chat?history=true&conversation_id=abc", {
+        headers: {
+          "X-Forwarded-For": ip,
+          "X-Shopify-Shop-Id": "123"
+        }
+      })
+    });
+
+    assert.notEqual(response.status, 429);
+  } finally {
+    await server.close();
+  }
+});
+
 routeTest("chat preflight allows the Shopify shop header", async () => {
+  process.env.NODE_ENV = "production";
+  process.env.ALLOWED_ORIGINS = "https://shop.example.com";
+
   const { server, route } = await loadChatRoute();
   try {
     const response = await route.loader({

--- a/test/cors.test.js
+++ b/test/cors.test.js
@@ -1,0 +1,37 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { isAllowedOrigin, corsOriginHeaders } from "../app/services/cors.server.js";
+
+test("trusts origins listed in ALLOWED_ORIGINS", () => {
+  process.env.NODE_ENV = "production";
+  process.env.ALLOWED_ORIGINS = "https://shop.example.com, https://other.example.com";
+  assert.equal(isAllowedOrigin("https://shop.example.com"), true);
+  assert.equal(isAllowedOrigin("https://other.example.com"), true);
+});
+
+test("rejects unknown origins in production", () => {
+  process.env.NODE_ENV = "production";
+  process.env.ALLOWED_ORIGINS = "https://shop.example.com";
+  assert.equal(isAllowedOrigin("https://evil.example.com"), false);
+  assert.equal(isAllowedOrigin(null), false);
+});
+
+test("allows localhost only outside production", () => {
+  process.env.ALLOWED_ORIGINS = "";
+  process.env.NODE_ENV = "development";
+  assert.equal(isAllowedOrigin("http://localhost:3000"), true);
+  process.env.NODE_ENV = "production";
+  assert.equal(isAllowedOrigin("http://localhost:3000"), false);
+});
+
+test("corsOriginHeaders is empty for untrusted origins", () => {
+  process.env.NODE_ENV = "production";
+  process.env.ALLOWED_ORIGINS = "https://shop.example.com";
+
+  const trusted = new Request("https://api.example.com", { headers: { Origin: "https://shop.example.com" } });
+  assert.equal(corsOriginHeaders(trusted)["Access-Control-Allow-Origin"], "https://shop.example.com");
+  assert.equal(corsOriginHeaders(trusted).Vary, "Origin");
+
+  const untrusted = new Request("https://api.example.com", { headers: { Origin: "https://evil.example.com" } });
+  assert.deepEqual(corsOriginHeaders(untrusted), {});
+});

--- a/test/rate-limiter.test.js
+++ b/test/rate-limiter.test.js
@@ -1,0 +1,58 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { allowRequest, clientKey, rateLimitExceeded } from "../app/services/rate-limiter.server.js";
+
+test("allows requests up to the limit, then blocks", () => {
+  const key = `k-${Math.random()}`;
+  assert.equal(allowRequest(key, 3), true);
+  assert.equal(allowRequest(key, 3), true);
+  assert.equal(allowRequest(key, 3), true);
+  assert.equal(allowRequest(key, 3), false);
+});
+
+test("the window resets after it expires", async () => {
+  const key = `k-${Math.random()}`;
+  assert.equal(allowRequest(key, 1, 20), true);
+  assert.equal(allowRequest(key, 1, 20), false);
+  await new Promise((resolve) => setTimeout(resolve, 30));
+  assert.equal(allowRequest(key, 1, 20), true);
+});
+
+test("endpoint prefixes isolate buckets", () => {
+  const request = new Request("https://example.com", {
+    headers: { "X-Forwarded-For": `1.2.3.${Math.floor(Math.random() * 255)}` }
+  });
+
+  assert.equal(rateLimitExceeded(request, "chat", 1), false);
+  assert.equal(rateLimitExceeded(request, "chat", 1), true);
+  assert.equal(rateLimitExceeded(request, "history", 1), false);
+});
+
+test("clientKey uses the rightmost forwarded IP", () => {
+  const request = new Request("https://example.com", {
+    headers: { "X-Forwarded-For": "1.2.3.4, 5.6.7.8", "X-Shopify-Shop-Id": "42" }
+  });
+  assert.equal(clientKey(request), "5.6.7.8");
+});
+
+test("clientKey does not include the client-supplied shop header", () => {
+  const first = new Request("https://example.com", {
+    headers: { "X-Forwarded-For": "1.2.3.4", "X-Shopify-Shop-Id": "42" }
+  });
+  const second = new Request("https://example.com", {
+    headers: { "X-Forwarded-For": "1.2.3.4", "X-Shopify-Shop-Id": "99" }
+  });
+
+  assert.equal(clientKey(first), clientKey(second));
+});
+
+test("clientKey returns null when the forwarded IP is missing", () => {
+  const request = new Request("https://example.com");
+  assert.equal(clientKey(request), null);
+});
+
+test("rate limiting is skipped when no client key is available", () => {
+  const request = new Request("https://example.com");
+  assert.equal(rateLimitExceeded(request, "chat", 1), false);
+  assert.equal(rateLimitExceeded(request, "chat", 1), false);
+});


### PR DESCRIPTION
## What this fixes

This follows the IDOR fix in #67 and closes the cross-origin / brute-force pieces called out in Shopify/consumer-agent#1826.

## What changed

- CORS no longer reflects arbitrary origins. Only origins in `ALLOWED_ORIGINS` are echoed back; localhost browser clients are allowed in development.
- CORS responses that echo an origin now include `Vary: Origin`.
- `.env.example` now calls out that Shopify storefront origins are required in every environment.
- Added a small in-memory rate limiter to chat, history, and token-status requests.
- Rate-limit buckets are scoped per endpoint, use the rightmost forwarded IP instead of client-supplied shop IDs, and do not collapse requests without `X-Forwarded-For` into a shared `unknown` bucket.
- Expired-bucket sweeps are throttled so high-cardinality traffic does not force a full map scan on every request.
- Chat rate-limit responses and all other pre-stream chat failures now return JSON headers instead of advertising `text/event-stream` for JSON bodies.
- The widget checks non-OK chat responses before reading the body as SSE, so HTTP 429 responses surface as a busy message instead of being parsed as stream frames.
- Token-status now uses the same conversation/shop validation before checking `CustomerToken`, so it no longer answers questions about raw `conversation_id` values.
- The widget sends `X-Shopify-Shop-Id` when polling token status.
- Added Node tests for CORS, rate-limit behavior, JSON response contracts, and Vite-backed route behavior.

## Stack

1. #67 — unguessable conversation IDs + shop-scoped conversation access.
2. This PR — CORS lockdown, rate limiting, and token-status hardening.

## Verification

- `node --test` — 28 passing, 5 Vite-backed route tests skipped locally because dependencies are not installed in this checkout.
- Syntax-checked touched JS/JSX/test files with `node --check`.
- `git diff --check`.
