### PR TITLE
Replacing deprecated claude sonnet version with sonnet 5

### DIFF
--- a/app/services/config.server.js
+++ b/app/services/config.server.js
@@ -6,7 +6,7 @@
 export const AppConfig = {
   // API Configuration
   api: {
-    defaultModel: 'claude-sonnet-4-20250514',
+    defaultModel: 'claude-sonnet-5',
     maxTokens: 2000,
     defaultPromptType: 'standardAssistant',
   },


### PR DESCRIPTION
Anthropic deprecated `claude-opus-4-20250514` on June 15, 2026. This PR replaces the default model with `claude-sonnet-5`. 

Without this update, the Claude queries fail with an ambiguous error of:

```
Error processing streaming request: NotFoundError: 404.....
```