### PR TITLE
fix: point customer auth redirect to localhost callback

### DIFF
--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -24,6 +24,8 @@ redirect_urls = [ "https://shop-chat-agent.com/api/auth" ]
 embedded = false
 
 [customer_authentication]
+# TODO: Swap for production/tunnel HTTPS URL when not using `shopify app dev --use-localhost` (Customer Account API may require a public HTTPS host).
+# Matches REDIRECT_URL in .env.example and the /auth/callback route (auth.callback.jsx); CLI reverse-proxies on port 3458.
 redirect_uris = [
-  "https://shop-chat-agent.com/callback"
+  "https://localhost:3458/auth/callback"
 ]


### PR DESCRIPTION
## Summary
- Update `[customer_authentication].redirect_uris` to `https://localhost:3458/auth/callback` so it matches the `/auth/callback` route and Shopify CLI `--use-localhost` proxy.
- Add short TODOs for swapping to a production/tunnel HTTPS URL when not using localhost.

## Test plan
- [ ] Run `shopify app dev --use-localhost` and confirm customer account auth callback hits `/auth/callback`
- [ ] Confirm `REDIRECT_URL` in `.env` / `.env.example` aligns with this URI
- [ ] For production deploy, replace with a public HTTPS redirect URI


Made with [Cursor](https://cursor.com)